### PR TITLE
Improve plugin development tutorial.

### DIFF
--- a/PluginDevelopmentTutorial.md
+++ b/PluginDevelopmentTutorial.md
@@ -65,13 +65,15 @@ Added MyModule to plugin.json
 Panel found at res/MyModule.svg. Generating source file.
 Found 1 params, 1 inputs, 1 outputs, 0 lights, and 0 custom widgets.
 Components extracted from res/MyModule.svgSource file generated at src/MyModule.cpp
-
-To enable the module, add
-extern Model *modelMyModule;
-to plugin.hpp, and add
-p->addModel(modelMyModule);
-to the init() function in plugin.cpp.
 ```
+
+To enable the module, add the following lines:
+
+```
+extern Model *modelMyModule; // plugin.hpp
+p->addModel(modelMyModule); // init() function in plugin.cpp
+```
+
 Open `MyModule.svg` with Inkscape, open the Layers panel, and hide the `components` layer to hide component placeholders.
 
 ## Implementing the DSP kernel


### PR DESCRIPTION
Before, the instructions to add extra lines to enable a module were hidden at the end of the example session. This commits breaks them out into their own section to make them more obvious.

At least two people have missed this in the last month: https://community.vcvrack.com/t/compiled-module-not-showing-up/5169